### PR TITLE
Update .openpublishing.publish.config.json

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -52,6 +52,10 @@
     "mapping/monikerMapping.json"
   ],
   "need_generate_pdf_url_template": false,
+  "xref_query_tags": [
+        "/dotnet",
+        "/uwp/api"
+  ],
   "dependent_packages": [
     {
       "id": "Microsoft.DocAsCode.MAML2Yaml",


### PR DESCRIPTION
Add  "xref_query_tags" to support autolinks for full typenames.