### PR TITLE
Update Get-EntraBetaCrossTenantAccessActivity.md

### DIFF
--- a/docs/reference/beta/Microsoft.Entra.Beta.Reports/Get-EntraBetaCrossTenantAccessActivity.md
+++ b/docs/reference/beta/Microsoft.Entra.Beta.Reports/Get-EntraBetaCrossTenantAccessActivity.md
@@ -46,7 +46,7 @@ In addition to delegated permissions, the signed-in user must belong to at least
 ### Example 1: Get all cross-tenant sign-in events
 
 ```powershell
-Connect-Entra -Scopes 'AuditLog.Read.All', 'CrossTenantInfo.ReadBasic.All'
+Connect-Entra -Scopes 'AuditLog.Read.All', 'CrossTenantInformation.ReadBasic.All'
 Get-EntraBetaCrossTenantAccessActivity
 ```
 


### PR DESCRIPTION
Suggesting update to correct Graph scope reference, as CrossTenantInfo.ReadBasic.All appears to have been replaced with CrossTenantInformation.ReadBasic.All